### PR TITLE
Add sglang daemon and compose updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,28 @@
 # sglang_workbench
+
+This repository provides utilities to manage distributed `sglang` servers using
+`docker compose`. Each container runs a small Python daemon that exposes an API
+for launching `sglang` with arbitrary commands. A helper CLI script can call
+all daemons to start the cluster at once.
+
+## Usage
+
+1. Build the Docker image and start the containers:
+
+   ```bash
+   docker compose up -d
+   ```
+
+   The compose file launches two containers (`sg-head` and `sg-worker1`) each
+   running `daemon.py`. The daemon listens on ports `18000` and `18001`
+   respectively.
+
+2. Start `sglang` on all containers with `start_daemons.py`:
+
+   ```bash
+   python3 start_daemons.py \
+       --hosts sg-head:18000 sg-worker1:18001 \
+       --command "python3 -m sglang.launch_server --node-rank RANK"
+   ```
+
+   Replace the command with the actual `sglang` launch command you wish to run.

--- a/daemon.py
+++ b/daemon.py
@@ -1,0 +1,59 @@
+import os
+import subprocess
+import threading
+from flask import Flask, request, jsonify
+
+app = Flask(__name__)
+RANK = int(os.environ.get("RANK", "0"))
+
+process = None
+process_lock = threading.Lock()
+
+
+def start_process(cmd):
+    global process
+    with process_lock:
+        if process and process.poll() is None:
+            return False, "process already running"
+        process = subprocess.Popen(cmd, shell=True)
+    return True, f"started: {cmd}"
+
+
+def stop_process():
+    global process
+    with process_lock:
+        if process and process.poll() is None:
+            process.terminate()
+            process.wait()
+            return True
+    return False
+
+
+@app.route('/run', methods=['POST'])
+def run_cmd():
+    data = request.get_json(force=True)
+    cmd = data.get('command')
+    if not cmd:
+        return jsonify({'error': 'command required'}), 400
+    ok, msg = start_process(cmd)
+    if ok:
+        return jsonify({'rank': RANK, 'status': 'started'})
+    else:
+        return jsonify({'rank': RANK, 'status': 'failed', 'message': msg}), 409
+
+
+@app.route('/stop', methods=['POST'])
+def stop_cmd():
+    stopped = stop_process()
+    return jsonify({'rank': RANK, 'stopped': stopped})
+
+
+@app.route('/status', methods=['GET'])
+def status():
+    running = process is not None and process.poll() is None
+    return jsonify({'rank': RANK, 'running': running})
+
+
+if __name__ == '__main__':
+    port = int(os.environ.get('DAEMON_PORT', 8000 + RANK))
+    app.run(host='0.0.0.0', port=port)

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -40,9 +40,13 @@ services:
     networks:
       - ray_network
     entrypoint: /root/sglang_workbench/entrypoint.sh
+    ports:
+      - "18000:18000"
     environment:
       <<: *common_env                  # 先把公共的全量拉进来
       ROLE: "head"
+      RANK: "0"
+      DAEMON_PORT: "18000"
       CUDA_MPS_ACTIVE_THREAD_PERCENTAGE: "20"  # 再追加或覆盖单个变量
       CUDA_MPS_PINNED_DEVICE_MEM_LIMIT: "0=24GB"
 
@@ -52,8 +56,12 @@ services:
     networks:
       - ray_network
     entrypoint: /root/sglang_workbench/entrypoint.sh
+    ports:
+      - "18001:18001"
     environment:
       <<: *common_env
       ROLE: "worker"
+      RANK: "1"
+      DAEMON_PORT: "18001"
       CUDA_MPS_ACTIVE_THREAD_PERCENTAGE: "80"
       CUDA_MPS_PINNED_DEVICE_MEM_LIMIT: "0=24GB"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -11,7 +11,9 @@ git config --global user.name "BAI Xu"
 git config --global user.email "baixu.must@gmail.com"
 
 service ssh restart
-tail -f /dev/null
+
+# Start the daemon that listens for incoming requests to launch sglang.
+python3 /root/sglang_workbench/daemon.py
 # if [ "$COMPOSE_RUNNING_MODE" == "EXPERIMENT" ]; then
 #     if [ "$ROLE" == "head" ]; then
 #         ray start --block --head --port=$RAY_PORT --dashboard-host=0.0.0.0 &

--- a/start_daemons.py
+++ b/start_daemons.py
@@ -1,0 +1,19 @@
+import argparse
+import requests
+
+def main():
+    parser = argparse.ArgumentParser(description="Start sglang on all daemons")
+    parser.add_argument('--hosts', nargs='+', required=True,
+                        help='list of host:port for each daemon')
+    parser.add_argument('--command', required=True, help='command to execute')
+    args = parser.parse_args()
+    for host in args.hosts:
+        url = f'http://{host}/run'
+        try:
+            r = requests.post(url, json={'command': args.command}, timeout=5)
+            print(f'{host}: {r.status_code} {r.text}')
+        except Exception as e:
+            print(f'{host}: failed to send request: {e}')
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Summary
- set up a simple Python server (`daemon.py`) that exposes an API for running `sglang` commands per container
- add a helper CLI (`start_daemons.py`) for triggering the daemons from the host
- update entrypoint to run the daemon when containers start
- expose daemon ports and ranks in `docker-compose.yaml`
- document usage in README

## Testing
- `python3 -m py_compile daemon.py start_daemons.py`

------
https://chatgpt.com/codex/tasks/task_e_684547fa4cd483258004f0a44815de6d